### PR TITLE
fix: ts types file path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "files": [
     "dist/"
   ],
-  "types": "index.d.ts",
+  "types": "./dist/index.d.ts",
   "dependencies": {
     "@noble/hashes": "~1.1.1",
     "@scure/base": "~1.1.0"


### PR DESCRIPTION
The ts types file path in `package.json` is not pointing to the right `dist` folder.

The package is at the moment throwing the following error while imported in other projects:
`Could not find a declaration file for module '@metamask/scure-bip39'`

Types path has been changed to `./dist/index.d.ts`