### PR TITLE
update mnemonicToSeed (async version) to accept mnemonic arg formatted as Uint8Array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,8 +141,8 @@ export function mnemonicToSeed(mnemonic: string | Uint8Array, wordlist: string[]
 
 /**
  * Irreversible: Uses KDF to derive 64 bytes of key data from mnemonic + optional password.
- * @param mnemonic 12-24 words | Uint8Array representation of mnemonic
- * @param wordlist an array of words used to recover the mnemonic string from a Uint8Array
+ * @param mnemonic 12-24 words (string | Uint8Array)
+ * @param wordlist array of 2048 words used to recover the mnemonic string from a Uint8Array
  * @param passphrase string that will additionally protect the key
  * @returns 64 bytes of key data
  * @example

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,8 @@ const salt = (passphrase: string) => nfkd(`mnemonic${passphrase}`);
 
 /**
  * Irreversible: Uses KDF to derive 64 bytes of key data from mnemonic + optional password.
- * @param mnemonic 12-24 words
+ * @param mnemonic 12-24 words | Uint8Array representation of mnemonic
+ * @param wordlist an array of words used to recover the mnemonic string from a Uint8Array
  * @param passphrase string that will additionally protect the key
  * @returns 64 bytes of key data
  * @example
@@ -133,13 +134,15 @@ const salt = (passphrase: string) => nfkd(`mnemonic${passphrase}`);
  * await mnemonicToSeed(mnem, 'password');
  * // new Uint8Array([...64 bytes])
  */
-export function mnemonicToSeed(mnemonic: string, passphrase = '') {
-  return pbkdf2Async(sha512, normalize(mnemonic).nfkd, salt(passphrase), { c: 2048, dkLen: 64 });
+export function mnemonicToSeed(mnemonic: string | Uint8Array, wordlist: string[], passphrase = '') {
+  const encodedMnemonicUint8Array = encodeMnemonicForSeedDerivation(mnemonic, wordlist);
+  return pbkdf2Async(sha512, encodedMnemonicUint8Array, salt(passphrase), { c: 2048, dkLen: 64 });
 }
 
 /**
  * Irreversible: Uses KDF to derive 64 bytes of key data from mnemonic + optional password.
- * @param mnemonic 12-24 words
+ * @param mnemonic 12-24 words | Uint8Array representation of mnemonic
+ * @param wordlist an array of words used to recover the mnemonic string from a Uint8Array
  * @param passphrase string that will additionally protect the key
  * @returns 64 bytes of key data
  * @example
@@ -152,15 +155,23 @@ export function mnemonicToSeedSync(
   wordlist: string[],
   passphrase = ''
 ) {
-  let mnemonicUint8Array;
+  const encodedMnemonicUint8Array = encodeMnemonicForSeedDerivation(mnemonic, wordlist);
+  return pbkdf2(sha512, encodedMnemonicUint8Array, salt(passphrase), { c: 2048, dkLen: 64 });
+}
+
+/**
+ * Helper function to encode mnemonic passed either as a string or `Uint8Array` for deriving a seed/key with pbkdf2.
+ */
+function encodeMnemonicForSeedDerivation(mnemonic: string | Uint8Array, wordlist: string[]) {
+  let encodedMnemonicUint8Array;
   if (typeof mnemonic === 'string') {
-    mnemonicUint8Array = new TextEncoder().encode(normalize(mnemonic).nfkd);
+    encodedMnemonicUint8Array = new TextEncoder().encode(normalize(mnemonic).nfkd);
   } else {
-    mnemonicUint8Array = new TextEncoder().encode(
+    encodedMnemonicUint8Array = new TextEncoder().encode(
       Array.from(new Uint16Array(mnemonic.buffer))
         .map((i) => wordlist[i])
         .join(' ')
     );
   }
-  return pbkdf2(sha512, mnemonicUint8Array, salt(passphrase), { c: 2048, dkLen: 64 });
+  return encodedMnemonicUint8Array;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,8 +125,8 @@ const salt = (passphrase: string) => nfkd(`mnemonic${passphrase}`);
 
 /**
  * Irreversible: Uses KDF to derive 64 bytes of key data from mnemonic + optional password.
- * @param mnemonic 12-24 words | Uint8Array representation of mnemonic
- * @param wordlist an array of words used to recover the mnemonic string from a Uint8Array
+ * @param mnemonic 12-24 words (string | Uint8Array)
+ * @param wordlist array of 2048 words used to recover the mnemonic string from a Uint8Array
  * @param passphrase string that will additionally protect the key
  * @returns 64 bytes of key data
  * @example

--- a/test/bip39.test.ts
+++ b/test/bip39.test.ts
@@ -150,7 +150,7 @@ describe('BIP39', () => {
 
       describe('Async', () => {
         it('Should recover the right seed', async () => {
-          const recoveredSeed = await mnemonicToSeed(mnemonic);
+          const recoveredSeed = await mnemonicToSeed(mnemonic, englishWordlist);
           await deepStrictEqual(equalsBytes(seed, recoveredSeed), true);
         });
       });
@@ -191,7 +191,7 @@ describe('BIP39', () => {
 
       describe('Async', () => {
         it('Should recover the right seed', async () => {
-          const recoveredSeed = await mnemonicToSeed(mnemonic, PASSPHRASE);
+          const recoveredSeed = await mnemonicToSeed(mnemonic, englishWordlist, PASSPHRASE);
           await deepStrictEqual(seed, recoveredSeed);
         });
       });
@@ -559,7 +559,7 @@ describe('BIP39', () => {
           seed,
           'mnemonicToSeedSync'
         );
-        const res = await mnemonicToSeed(mnemonic, password);
+        const res = await mnemonicToSeed(mnemonic, englishWordlist, password);
         await deepStrictEqual(toHex(res), seed, 'mnemonicToSeed');
         await deepStrictEqual(
           entropyToMnemonic(hexToBytes(entropy), wordlist),


### PR DESCRIPTION
CHANGED: Update mnemonicToSeed (async version) to accept mnemonic arg formatted as Uint8Array in the same way that it's synchronous counterpart `mnemonicToSeedSync` does.